### PR TITLE
fixed mainMenu event listeners to be jQuery

### DIFF
--- a/browser/js/mainMenu/mainMenu.js
+++ b/browser/js/mainMenu/mainMenu.js
@@ -19,8 +19,8 @@ app.controller('MainMenuCtrl', function ($scope, $state) {
   };
 
   var menuLength = $('.menuXParent').children().length;
-
-  window.addEventListener('keydown', onArrowKey)
+  var $document = $(document);
+  $document.on('keydown', onArrowKey)
   function onArrowKey(event) {
       var active = $('.activeChoice');
       var activeNumber = parseInt(active[0].id.slice(-1));
@@ -37,10 +37,10 @@ app.controller('MainMenuCtrl', function ($scope, $state) {
       $('#option' + activeNumber).addClass("activeChoice");
     } else if(event.keyCode === 13) {
       var uiState = active[0].outerHTML.split('"');
-      window.removeEventListener('keydown', onArrowKey);
+      $document.off('keydown', onArrowKey);
       $state.go(uiState[menuLength]);
     } else if(event.keyCode === 27) {
-      window.removeEventListener('keydown', onArrowKey);
+      $document.off('keydown', onArrowKey);
       $state.go('home');
     };
   };

--- a/browser/scss/mainMenu/main.scss
+++ b/browser/scss/mainMenu/main.scss
@@ -15,8 +15,9 @@
   font-family: EchoDeco;
   font-weight: 10;
   font-size: 60px;
+  height: 60px;
   color: #ea4c88;
-  padding-top: 2%;
+  padding-top: 7%;
   text-align: center;
   // background-color: red;
 }


### PR DESCRIPTION
this is an old fix that i think was lost in previous merge problems.  
changed the mainMenu event listeners to be jQuery instead of window.EventListeners.
changed the spacing so that the menu does not "bounce" when going from top to bottom of menu
